### PR TITLE
[FEATURE] Trier par ordre alphabétique les imports et exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: 'script',
   },
+  plugins: ["simple-import-sort"],
   env: {
     es6: true,
     node: true,
@@ -72,6 +73,8 @@ module.exports = {
     'prefer-const': ['error'],
     quotes: ['error', 'single'],
     semi: ['error', 'always'],
+    'simple-import-sort/imports': 'error',
+    'simple-import-sort/exports': 'error',
     'space-before-blocks': ['error'],
     'space-before-function-paren': [
       'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@1024pix/eslint-plugin": "^1.0.0",
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-i18n-json": "^4.0.0",
+        "eslint-plugin-simple-import-sort": "^10.0.0",
         "eslint-plugin-yml": "^1.8.0"
       },
       "devDependencies": {
@@ -2090,6 +2091,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-10.0.0.tgz",
+      "integrity": "sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==",
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-plugin-yml": {
@@ -6502,6 +6511,12 @@
           }
         }
       }
+    },
+    "eslint-plugin-simple-import-sort": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-10.0.0.tgz",
+      "integrity": "sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==",
+      "requires": {}
     },
     "eslint-plugin-yml": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@1024pix/eslint-plugin": "^1.0.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-i18n-json": "^4.0.0",
+    "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-yml": "^1.8.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## :unicorn: Problème
Actuellement les imports sont dans tous les ordres et nous pouvons passer à côté de certains. De plus, ils ne sont pas forcément regroupés.

## :robot: Proposition
Ajouter la librairie https://github.com/lydell/eslint-plugin-simple-import-sort qui fait bien le travail et surtout qui a les règles pour fixer automatiquement les problèmes contraire à [la règle de eslint `sort-imports`](https://eslint.org/docs/latest/rules/sort-imports) (cf: https://github.com/eslint/eslint/issues/11542) 

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
- Voir la PR sur le monorepo https://github.com/1024pix/pix/compare/tech-sort-imports