### PR TITLE
[DOCS] Ajoute `@1024pix/eslint-plugin` dans la procédure d'install

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ### Install
 
 ```bash
-npm install -D eslint @1024pix/eslint-config
+npm install -D eslint @1024pix/eslint-config @1024pix/eslint-plugin
 ```
 
 ### Config `.eslintrc`


### PR DESCRIPTION
## :unicorn: Problème
Pour pouvoir utiliser la dernière version de `@1024pix/eslint-config` il faut installer `@1024pix/eslint-plugin`. Ce n'est pas précisé dans la doc d'install

## :robot: Proposition
L'ajouter.

## :rainbow: Remarques
RAS

## :100: Pour tester
RAS