### PR TITLE
[TECH] Déplacer le plugin eslint 1024pix directement dans ce projet

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 const path = require('node:path');
 const noSinonStubWithArgsOneliner = require('./rules/no-sinon-stub-with-args-oneliner.js');
 
+/** @type {import('eslint').Linter.Config} */
 module.exports = {
   extends: [
     'eslint:recommended',

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const path = require('node:path');
+const noSinonStubWithArgsOneliner = require('./rules/no-sinon-stub-with-args-oneliner.js');
 
 module.exports = {
   extends: [
@@ -8,7 +9,15 @@ module.exports = {
     'plugin:eslint-comments/recommended',
     'plugin:i18n-json/recommended',
   ],
-  plugins: ['@1024pix'],
+  plugins: [
+    {
+      '@1024pix': {
+        rules: {
+          'no-sinon-stub-with-args-oneliner': noSinonStubWithArgsOneliner,
+        },
+      },
+    },
+  ],
   root: true,
   parserOptions: {
     ecmaVersion: 2018,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "@1024pix/eslint-config",
       "version": "1.1.2",
       "dependencies": {
-        "@1024pix/eslint-plugin": "^1.0.0",
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-i18n-json": "^4.0.0",
         "eslint-plugin-yml": "^1.8.0"
@@ -20,11 +19,6 @@
       "peerDependencies": {
         "eslint": ">=8.0.0"
       }
-    },
-    "node_modules/@1024pix/eslint-plugin": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/eslint-plugin/-/eslint-plugin-1.0.0.tgz",
-      "integrity": "sha512-jjNmwbnTQ2G9NxYxHWQTWxpxBmkG7VqBLBgwaka+i/xfXWLC6zoAzuhNJYlfzWCOZ1fw3Di+PiPZ3t8lAtu7aw=="
     },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
@@ -4919,11 +4913,6 @@
     }
   },
   "dependencies": {
-    "@1024pix/eslint-plugin": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@1024pix/eslint-plugin/-/eslint-plugin-1.0.0.tgz",
-      "integrity": "sha512-jjNmwbnTQ2G9NxYxHWQTWxpxBmkG7VqBLBgwaka+i/xfXWLC6zoAzuhNJYlfzWCOZ1fw3Di+PiPZ3t8lAtu7aw=="
-    },
     "@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "prettier": "^3.0.0"
   },
   "dependencies": {
-    "@1024pix/eslint-plugin": "^1.0.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-i18n-json": "^4.0.0",
     "eslint-plugin-yml": "^1.8.0"

--- a/rules/no-sinon-stub-with-args-oneliner.js
+++ b/rules/no-sinon-stub-with-args-oneliner.js
@@ -1,0 +1,38 @@
+function report(context, node) {
+  context.report({
+    node: node,
+    messageId: 'chainError',
+  });
+}
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Do not chain `sinon.stub()` with the `withArgs()` method in a one-liner',
+    },
+    messages: {
+      chainError:
+        '`sinon.stub()` should not be chained with the `withArgs` method.',
+    },
+  },
+  create: (context) => ({
+    'VariableDeclarator > CallExpression > MemberExpression[property.name="returns"] > CallExpression > MemberExpression[property.name="withArgs"] > CallExpression > MemberExpression[property.name="stub"][object.name="sinon"]':
+      (node) => {
+        report(context, node);
+      },
+    'VariableDeclarator > CallExpression > MemberExpression[property.name="throws"] > CallExpression > MemberExpression[property.name="withArgs"] > CallExpression > MemberExpression[property.name="stub"][object.name="sinon"]':
+      (node) => {
+        report(context, node);
+      },
+    'VariableDeclarator > CallExpression > MemberExpression[property.name="resolves"] > CallExpression > MemberExpression[property.name="withArgs"] > CallExpression > MemberExpression[property.name="stub"][object.name="sinon"]':
+      (node) => {
+        report(context, node);
+      },
+    'VariableDeclarator > CallExpression > MemberExpression[property.name="rejects"] > CallExpression > MemberExpression[property.name="withArgs"] > CallExpression > MemberExpression[property.name="stub"][object.name="sinon"]':
+      (node) => {
+        report(context, node);
+      },
+  }),
+};

--- a/rules/no-sinon-stub-with-args-oneliner.js
+++ b/rules/no-sinon-stub-with-args-oneliner.js
@@ -5,6 +5,7 @@ function report(context, node) {
   });
 }
 
+/** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'problem',

--- a/rules/no-sinon-stub-with-args-oneliner.test.js
+++ b/rules/no-sinon-stub-with-args-oneliner.test.js
@@ -1,0 +1,60 @@
+const rule = require('./no-sinon-stub-with-args-oneliner.js');
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+});
+
+ruleTester.run('no-sinon-stub-with-args-oneliner', rule, {
+  valid: [
+    {
+      name: 'Only stub',
+      code: 'sinon.stub()',
+    },
+    {
+      name: 'Sinon import then two liners',
+      code: "const stub = sinon.stub(); stub.withArgs('hello').returns('world')",
+    },
+    {
+      name: 'Sinon import then object definition',
+      code: "import sinon from 'sinon'; const stub = { hello: sinon.stub().withArgs('hello').returns('world') }",
+    },
+    {
+      name: 'Stub import then two liners',
+      code: "import { stub } from 'sinon'; const myStub = stub(); myStub.withArgs('hello').returns('world')",
+    },
+
+    // Not handled yet
+    {
+      name: 'Sinon import then onCall one liner',
+      code: "import sinon from 'sinon'; const myStub = sinon.stub().withArgs('hello').onCall(0).returns('world')",
+    },
+    {
+      name: 'Stub import then one liner',
+      code: "import { stub } from 'sinon'; const myStub = stub().withArgs('hello').returns('world')",
+    },
+  ],
+
+  invalid: [
+    {
+      name: 'One liner variable assignment with sinon import and returns',
+      code: `import sinon from 'sinon'; const stub = sinon.stub().withArgs('hello').returns('world')`,
+      errors: [{ messageId: 'chainError' }],
+    },
+    {
+      name: 'One liner variable assignment with sinon import and throws',
+      code: `import sinon from 'sinon'; const stub = sinon.stub().withArgs('hello').throws('world')`,
+      errors: [{ messageId: 'chainError' }],
+    },
+    {
+      name: 'One liner variable assignment with sinon import and resolves',
+      code: `import sinon from 'sinon'; const stub = sinon.stub().withArgs('hello').resolves('world')`,
+      errors: [{ messageId: 'chainError' }],
+    },
+    {
+      name: 'One liner variable assignment with sinon import and rejects',
+      code: `import sinon from 'sinon'; const stub = sinon.stub().withArgs('hello').rejects('world')`,
+      errors: [{ messageId: 'chainError' }],
+    },
+  ],
+});


### PR DESCRIPTION
## :unicorn: Problème
Le plugin custom [`@1024pix/eslint-plugin`](https://github.com/1024pix/eslint-plugin) n'a pas de raison d'être. Il a été créé par mécompréhension de ma part.

D'ailleurs on constate qu'il est installé un bon nombre de fois alors que c'est uniquement une dépendance de notre eslint-config...

![image](https://github.com/1024pix/eslint-config/assets/5855339/b760b679-e4fc-4b9a-b47d-47e5dd74356e)

## :robot: Proposition
Rapatrier le contenu du plugin dans ce projet.

## :rainbow: Remarques
J'ai ajouté des [typings](https://jsdoc.app/tags-type) ESLint pour améliorer la DX.

## :100: Pour tester
Pas de certitude... Si vous connaissez des outils pour valider les configs `eslint` ça peut servir dans nos tests !
