### PR TITLE
[TECH] Ajoute des métadonnées `npm`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,10 @@
   },
   "peerDependencies": {
     "eslint": ">=8.0.0"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/1024pix/eslint-config.git"
+  },
+  "homepage": "https://github.com/1024pix/eslint-config#readme"
 }


### PR DESCRIPTION
## :unicorn: Problème
Depuis [npmjs.org](https://www.npmjs.com/package/@1024pix/eslint-config) on ne trouve pas autant d'infos que sur d'autres projets :

**eslint-config**
![image](https://github.com/1024pix/eslint-config/assets/5855339/1f9f29f7-1c35-4874-8752-a74757b254a9)

**stylelint-config**
![image](https://github.com/1024pix/eslint-config/assets/5855339/514722b3-bde9-471a-9cdd-48562b23b66e)

Le champ `repository` permet notamment à Renovate d'ajouter une section changelog directement dans la PR de bump. https://docs.renovatebot.com/key-concepts/changelogs/#troubleshooting-missing-changelogs

## :robot: Proposition
Ajouter ces champs.

## :rainbow: Remarques
RAS

## :100: Pour tester
🤷 
