### PR TITLE
[BUGFIX] Accepter l'utilisation de Fetch

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,13 +54,6 @@ module.exports = {
         message: 'Use only faker.internet.exampleEmail()',
       },
     ],
-    'no-restricted-globals': [
-      'error',
-      {
-        name: 'fetch',
-        message: "Use import fetch from 'fetch'",
-      },
-    ],
     'no-unused-vars': [
       'error',
       {


### PR DESCRIPTION
## :unicorn: Problème
Avec les nouvelles versions de nodejs fetch est supporté directement par Node, et est inclu nativement, sans import nécessaire.

## :robot: Proposition
Retirer la restriction empêchant d'utiliser Fetch sans import qui n'est plus nécessaire.

## :rainbow: Remarques
Pas de remarque.

## :100: Pour tester
Vérifier que les tests passent bien.